### PR TITLE
Trip retrieval API now organizes by license plate

### DIFF
--- a/access-db.js
+++ b/access-db.js
@@ -372,6 +372,11 @@ async function getTripsForCompany(companyEmail, licensePlateFilter) {
 
 async function getEmissionsPerVehicle(companyEmail, licensePlateFilter) {
     const companyToQuery = await this.getCompanyByContactEmail(companyEmail);
+
+    if (companyToQuery === null || companyToQuery === undefined) {
+        return [];
+    }
+
     var equipmentList = companyToQuery.ownedEquipment;
     var trips = [];
     var emissions = [];

--- a/access-db.js
+++ b/access-db.js
@@ -358,12 +358,12 @@ async function getTripsForCompany(companyEmail, licensePlateFilter) {
 
     var equipmentList = companyToQuery.ownedEquipment;
 
-    var trips = [];
+    var trips = {};
     for (var i in equipmentList) {
         var vehicle = equipmentList[i];
 
         if (licensePlateFilter === null || licensePlateFilter === vehicle.licensePlate) {
-            trips = trips.concat(vehicle.trips);
+            trips[vehicle.licensePlate] = vehicle.trips;
         }
     }
 

--- a/routes/company-routes.js
+++ b/routes/company-routes.js
@@ -303,21 +303,22 @@ module.exports = function (app) {
     })
 
     app.post('/getEmissionsPerVehicle', async (req, res) => {
-        const licencePlate = req.body.licencePlate;
+        const licensePlate = req.body.licensePlate;
         const companyEmail = req.body.companyEmail;
-            //response type
-            res.contentType('application/json');
 
-            //change this to info from the db
-            var items = Object.assign({}, await db.getEmissionsPerVehicle(companyEmail, licencePlate)); // combine the result with an empty object to ensure items is not undefined
-             var size = Object.keys(items).length; // get the number of keys in the object
+        //response type
+        res.contentType('application/json');
 
-            //send the response
-            if (items['error']) {
-                res.json({ error: items['error'] });
-            } else {
-                res.json(items);
-            }
+        //change this to info from the db
+        var items = Object.assign({}, await db.getEmissionsPerVehicle(companyEmail, licensePlate)); // combine the result with an empty object to ensure items is not undefined
+        var size = Object.keys(items).length; // get the number of keys in the object
+
+        //send the response
+        if (items['error']) {
+            res.json({ error: items['error'] });
+        } else {
+            res.json(items);
+        }
     })
 
     app.post('/getCompanyVehicles', async (req, res) => {


### PR DESCRIPTION
– Trip retrieval API has been updated to include the license plate in the returned data, and organize trips by license plate (they will be sorted as needed in the client)
– Changes to company-routes.js are very minimal, I changed the British spelling "licence" to the American "license" to avoid confusion because I used American spelling elsewhere in the app already. The remaining changes are just the autoformatter

This PR is co-requisite with PR#?? on client. They must both be merged (and successfully deployed) at the same time to avoid breaking the app.